### PR TITLE
feat: Implement learn selected words functionality

### DIFF
--- a/lib/database_helper.dart
+++ b/lib/database_helper.dart
@@ -103,4 +103,18 @@ class DatabaseHelper {
 
     return maps;
   }
+
+  Future<void> updateLearnedStatus(List<int> ids, int learnedValue) async {
+    final db = await database;
+    final batch = db.batch();
+    for (final id in ids) {
+      batch.update(
+        'Translations',
+        {'learned': learnedValue},
+        where: 'id = ?',
+        whereArgs: [id],
+      );
+    }
+    await batch.commit(noResult: true);
+  }
 }

--- a/lib/vocabulary_service.dart
+++ b/lib/vocabulary_service.dart
@@ -56,12 +56,13 @@ class VocabularyService {
     return true; // Topic already exists
   }
 
-  Future<List<Map<String, String>>> getVocabularyWords({
+  Future<List<Map<String, dynamic>>> getVocabularyWords({
     required int vocabId,
   }) async {
     final db = await DatabaseHelper().database;
     final List<Map<String, dynamic>> maps = await db.query(
       'Translations',
+      columns: ['id', 'original_word', 'transl_word', 'learned'],
       where: 'vocabulary = ?',
       whereArgs: [vocabId],
     );
@@ -70,26 +71,16 @@ class VocabularyService {
       return [];
     }
 
-    // Group translations by original_word
-    final Map<String, List<String>> groupedWords = {};
+    // Format for display
+    final List<Map<String, dynamic>> vocabularyList = [];
     for (var item in maps) {
-      final originalWord = item['original_word'] as String;
-      final translatedWord = item['transl_word'] as String;
-
-      if (!groupedWords.containsKey(originalWord)) {
-        groupedWords[originalWord] = [];
-      }
-      groupedWords[originalWord]!.add(translatedWord);
-    }
-
-    // Format for display, joining multiple translations if they exist
-    final List<Map<String, String>> vocabularyList = [];
-    groupedWords.forEach((originalWord, translations) {
       vocabularyList.add({
-        'english': originalWord,
-        'translation': translations.join(', '), // Join multiple translations
+        'id': item['id'] as int,
+        'english': item['original_word'] as String,
+        'translation': item['transl_word'] as String,
+        'learned': item['learned'] as int,
       });
-    });
+    }
 
     return vocabularyList;
   }


### PR DESCRIPTION
This commit introduces the following changes to the words list screen:

- Adds checkboxes to each word item in the vocabulary list on "screen2_words_list.dart".
- Each list item now correctly uses its unique ID from the "Translations" database table.
- Modifies `VocabularyService.getVocabularyWords` to fetch and provide `id` and `learned` status for each word, and removes word grouping to ensure each translatable item is distinct.
- Adds a "Learn selected words" button to "screen2_words_list.dart".
- Pressing the button updates the "learned" status to 2 in the "Translations" table for all selected words. This is handled by a new `updateLearnedStatus` method in `DatabaseHelper` which uses batch database operations.
- The UI refreshes after updating the words to reflect their new learned state.