### PR TITLE
feat: Implement cloud logging and fix screen2 word display

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -1,0 +1,3 @@
+// lib/config/constants.dart
+
+const String googleCloudProjectId = 'langpocket-8ffff';

--- a/lib/gemini_api_helper.dart
+++ b/lib/gemini_api_helper.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:LangPocket/services/logging_service.dart';
 
 const String GEMINI_API_KEY = String.fromEnvironment('GEMINI_API_KYE', defaultValue: 'AIzaSyATFZfhzaC9kBJcLqRk1WGA4PNxtWEsE5Y');
 const String apiUrl = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
@@ -88,11 +89,13 @@ Future<String> getVocabularyData(String languageLevel, String topic, String lang
       // Handle HTTP error
       print('Error calling Gemini API: ${response.statusCode}');
       print('Response body: ${response.body}');
+      await logError('Error calling Gemini API: ${response.statusCode}', error: response.body);
       return 'Error: Failed to fetch vocabulary data. Status code: ${response.statusCode}';
     }
-  } catch (e) {
+  } catch (e, s) {
     // Handle any exceptions during the process (e.g., network errors)
     print('Exception during Gemini API call: $e');
+    await logError('Exception during Gemini API call', error: e, stackTrace: s);
     return 'Error: An exception occurred while calling the API: ${e.toString()}';
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -285,6 +285,8 @@ class _MyHomePageState extends State<MyHomePage> {
                   }
 
                   // Navigate to the next screen after successful data handling
+                  // Navigate to the next screen after successful data handling
+                  final String selectedVocabularyName = _vocabularies.firstWhere((v) => v['id'] == _selectedVocabularyId)['Name'];
                   Navigator.push(
                     context,
                     MaterialPageRoute(
@@ -296,6 +298,7 @@ class _MyHomePageState extends State<MyHomePage> {
                             level: level,
                             vocabId: _selectedVocabularyId,
                             translCode: languageCode,
+                            vocabularyName: selectedVocabularyName, // Pass the name
                           ),
                     ),
                   );

--- a/lib/screen2_words_list.dart
+++ b/lib/screen2_words_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'database_helper.dart'; // Ensure DatabaseHelper is imported
 import 'vocabulary_service.dart'; // Import the new service
+import 'package:LangPocket/services/logging_service.dart';
 
 class EmotionWordsScreen extends StatefulWidget {
   const EmotionWordsScreen({
@@ -9,12 +10,14 @@ class EmotionWordsScreen extends StatefulWidget {
     this.vocabId = 0,
     required this.level,
     required this.translCode,
+    required this.vocabularyName, // Added
   });
 
   final String nativeLanguageCode;
   final int vocabId;
   final String level;
   final String translCode;
+  final String vocabularyName; // Added
 
   @override
   // ignore: library_private_types_in_public_api
@@ -33,6 +36,7 @@ class _EmotionWordsScreenState extends State<EmotionWordsScreen> {
   }
 
   Future<void> _fetchAndDisplayVocabulary() async {
+    // DIAGNOSTIC PRINTS REMOVED
     setState(() {
       _isLoading = true;
     });
@@ -47,7 +51,7 @@ class _EmotionWordsScreenState extends State<EmotionWordsScreen> {
       // Let's assume these are sufficient to identify and fetch the correct vocabulary.
       final success = await vocabularyService.fetchAndSaveVocabulary(
         vocabularyId: widget.vocabId,
-        selectedVocabulary: 'Emotion Words', // This might need refinement depending on actual usage
+        selectedVocabulary: widget.vocabularyName, // UPDATED
         level: widget.level,
         selectedNativeLanguage: widget.nativeLanguageCode,
         languageCode: widget.translCode,
@@ -75,10 +79,11 @@ class _EmotionWordsScreenState extends State<EmotionWordsScreen> {
           const SnackBar(content: Text('Failed to fetch and save vocabulary.')),
         );
       }
-    } catch (e) {
+    } catch (e, s) {
       setState(() {
         _isLoading = false;
       });
+      await logError('An error occurred in _fetchAndDisplayVocabulary', error: e, stackTrace: s);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('An error occurred: ${e.toString()}')),
       );
@@ -89,7 +94,7 @@ class _EmotionWordsScreenState extends State<EmotionWordsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Emotion Words'), // Title might become dynamic based on vocabulary
+        title: Text(widget.vocabularyName), // UPDATED
         backgroundColor: Colors.orange[700], // Warm color
       ),
       body: Container(

--- a/lib/services/logging_service.dart
+++ b/lib/services/logging_service.dart
@@ -1,0 +1,40 @@
+// lib/services/logging_service.dart
+
+import 'package:google_cloud_logging/google_cloud_logging.dart';
+import 'package:LangPocket/config/constants.dart'; // Corrected import path
+
+// It's good practice to use a specific logger name
+final _logger = GoogleCloudLogging(projectId: googleCloudProjectId).logger('LangPocketApp');
+
+Future<void> logError(
+  String message, {
+  Object? error,
+  StackTrace? stackTrace,
+}) async {
+  try {
+    print('Logging error: $message, Error: $error'); // For local debugging
+    
+    final entry = LogEntry(
+      severity: Severity.error,
+      message: message,
+      // Add more structured data if needed, for example, the error object and stack trace
+      // For just a simple message, this is fine.
+      // For more complex scenarios, you might want to include 'error.toString()' and 'stackTrace.toString()'
+      // in the jsonPayload if the backend supports it or if you structure your logs that way.
+      jsonPayload: {
+        'message': message,
+        if (error != null) 'error': error.toString(),
+        if (stackTrace != null) 'stackTrace': stackTrace.toString(),
+      },
+    );
+    
+    await _logger.writeEntries([entry]);
+    print('Successfully logged to Google Cloud Logging.'); // For local debugging
+  } catch (e, s) {
+    // If logging to Google Cloud fails, print to console as a fallback.
+    // Avoid trying to log this error using logError again, to prevent infinite loops.
+    print('Failed to send log to Google Cloud Logging: $e');
+    print('Original error: $message, Error: $error, StackTrace: $stackTrace');
+    print('Logging service stacktrace: $s');
+  }
+}

--- a/lib/vocabulary_service.dart
+++ b/lib/vocabulary_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'database_helper.dart';
 import 'gemini_api_helper.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:LangPocket/services/logging_service.dart';
 
 class VocabularyService {
   Future<bool> fetchAndSaveVocabulary({
@@ -17,8 +18,10 @@ class VocabularyService {
       level,
       languageCode,
     );
+    // DIAGNOSTIC PRINT REMOVED
 
     if (!exists) {
+      // DIAGNOSTIC PRINT REMOVED
       // Pass the level as String to getVocabularyData, assuming it can handle it or
       // that the gemini_api_helper needs to be updated to handle double if necessary.
       // Based on the error message, it seems getVocabularyData expects a String.
@@ -48,8 +51,9 @@ class VocabularyService {
           }
         }
         return true; // Data fetched and saved successfully
-      } catch (e) {
+      } catch (e, s) {
         print('Error decoding or saving vocabulary data: $e');
+        await logError('Error decoding or saving vocabulary data', error: e, stackTrace: s);
         return false; // Error occurred
       }
     }
@@ -59,6 +63,7 @@ class VocabularyService {
   Future<List<Map<String, dynamic>>> getVocabularyWords({
     required int vocabId,
   }) async {
+    // DIAGNOSTIC PRINT REMOVED
     final db = await DatabaseHelper().database;
     final List<Map<String, dynamic>> maps = await db.query(
       'Translations',
@@ -66,8 +71,10 @@ class VocabularyService {
       where: 'vocabulary = ?',
       whereArgs: [vocabId],
     );
+    // DIAGNOSTIC PRINT REMOVED
 
     if (maps.isEmpty) {
+      // DIAGNOSTIC PRINT REMOVED
       return [];
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   sqflite: ^2.4.2
   path: ^1.9.1
   http: ^1.2.1
+  google_cloud_logging: ^1.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Implemented Google Cloud Logging:
- Added `google_cloud_logging` dependency.
- Created a configuration file for the Google Cloud project ID.
- Developed a logging service (`logging_service.dart`) to send formatted error messages (including error objects and stack traces) to Google Cloud.
- Integrated this service into existing error handling blocks in `gemini_api_helper.dart`, `vocabulary_service.dart`, and `screen2_words_list.dart`.

Fixed "No vocabulary words found" issue in `screen2_words_list.dart`:
- Identified that a hardcoded topic name ("Emotion Words") in `screen2_words_list.dart` caused inconsistencies with data existence checks and fetching logic.
- Modified `EmotionWordsScreen` to accept and use a dynamic `vocabularyName` passed from `main.dart`.
- This ensures that the application consistently refers to the correct vocabulary topic when checking for, fetching, and displaying words.
- Removed temporary diagnostic logs added during debugging.